### PR TITLE
Fix cache-healthcheck route

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -39,7 +39,7 @@ app.prepare().then( () => {
 	const server = express();
 
 	// Cache healthcheck endpoint
-	server.get( '/cache-healthcheck', ( _req, res ) => {
+	server.get( '/cache-healthcheck?', ( _req, res ) => {
 		res.status( 200 ).send( 'Ok' );
 	} );
 


### PR DESCRIPTION
There was a missing `?` in our `/cache-healthcheck` route. This fixes it