### PR TITLE
Remove the `terms` connection on `ContentNode`

### DIFF
--- a/graphql/fragments/ContentNode.graphql
+++ b/graphql/fragments/ContentNode.graphql
@@ -29,11 +29,4 @@ fragment ContentNodeFields on ContentNode {
 	... on NodeWithTitle {
 		title
 	}
-	terms {
-		nodes {
-			id
-			name
-			slug
-		}
-	}
 }


### PR DESCRIPTION
Remove the `terms` connection on `ContentNode`, which required a patch on WPGraphQL. The patch is removed by https://github.com/Automattic/vip-decoupled-bundle/pull/34.

This connection was not actually used in the boilerplate and it's probably not the best approach long-term. Taxonomies should have specific connections to the post types that support them.