### PR TITLE
Fix/Image size on media page

### DIFF
--- a/pages/media/index.tsx
+++ b/pages/media/index.tsx
@@ -57,6 +57,7 @@ export default function Media( props: Props ) {
 										:
 										<Image
 											alt={altText}
+											layout="intrinsic"
 											height={100}
 											src={sourceUrl}
 											width={width / height * 100}


### PR DESCRIPTION
## Summary

- With the updates on Next/Image component on Next.js version 12, the media page was rendering differently regarding the width/height sizes.
- Based on [documentation](https://nextjs.org/docs/api-reference/next/image#layout), now we're using `layout="intrinsic"` instead of `layout="responsive"` as the default on our [Image component](https://github.com/Automattic/vip-go-nextjs-skeleton/blob/trunk/components/Image/Image.tsx).

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/199867/147693160-a8dd5431-0fca-4ab4-af3b-81f5254c5fb6.png)

### After
![image](https://user-images.githubusercontent.com/199867/147693046-c3fe6da4-c300-43db-af54-bfdd1ac9b885.png)
