### PR TITLE
Added html img component instad of next/image when using srcSet

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
 		"next/core-web-vitals"
 	],
 	"rules": {
-		"indent": [ "error", "tab", { "SwitchCase": 1 } ]
+		"indent": [ "error", "tab", { "SwitchCase": 1 } ],
+		"@next/next/no-img-element": "off"
 	}
 }

--- a/components/PostContent/PostContent.tsx
+++ b/components/PostContent/PostContent.tsx
@@ -29,7 +29,7 @@ export default function PostContent( props: {
 							};
 							if ( VipConfig.images.useHtmlTag && imageProps.srcSet ) {
 								return (
-									<img alt={blockProps.alt} {...defaultProps} />
+									<img alt={blockProps.alt} {...imageProps} />
 								);
 							}
 							return (

--- a/components/PostContent/PostContent.tsx
+++ b/components/PostContent/PostContent.tsx
@@ -1,3 +1,4 @@
+import config from '../../next.config';
 import ClassicEditorBlock from '@/components/ClassicEditorBlock/ClassicEditorBlock';
 import Heading from '@/components/Heading/Heading';
 import Paragraph from '@/components/Paragraph/Paragraph';
@@ -26,7 +27,7 @@ export default function PostContent( props: {
 								height: blockProps.height || blockProps.originalHeight,
 								srcSet: blockProps.srcSet || undefined,
 							};
-							if ( imageProps.srcSet ) {
+							if ( config.images.useHtmlTag && imageProps.srcSet ) {
 								return (
 									<img alt={blockProps.alt} {...defaultProps} />
 								);

--- a/components/PostContent/PostContent.tsx
+++ b/components/PostContent/PostContent.tsx
@@ -19,15 +19,18 @@ export default function PostContent( props: {
 
 					switch ( block.name ) {
 						case 'core/image':
-							// next/image don't have support to srcSet prop. Instead of send it,
-							// you need update imageSizes/deviceSizes on next.config.js file,
-							// or use <img />
 							const imageProps = {
 								...defaultProps,
 								src: blockProps.src,
 								width: blockProps.width || blockProps.originalWidth,
 								height: blockProps.height || blockProps.originalHeight,
+								srcSet: blockProps.srcSet || undefined,
 							};
+							if ( imageProps.srcSet ) {
+								return (
+									<img alt={blockProps.alt} {...defaultProps} />
+								);
+							}
 							return (
 								<Image alt={blockProps.alt} {...imageProps} />
 							);

--- a/components/PostContent/PostContent.tsx
+++ b/components/PostContent/PostContent.tsx
@@ -1,4 +1,4 @@
-import config from '../../next.config';
+import VipConfig from '../../vip.config';
 import ClassicEditorBlock from '@/components/ClassicEditorBlock/ClassicEditorBlock';
 import Heading from '@/components/Heading/Heading';
 import Paragraph from '@/components/Paragraph/Paragraph';
@@ -22,12 +22,12 @@ export default function PostContent( props: {
 						case 'core/image':
 							const imageProps = {
 								...defaultProps,
+								srcSet: blockProps.srcset || undefined,
 								src: blockProps.src,
 								width: blockProps.width || blockProps.originalWidth,
 								height: blockProps.height || blockProps.originalHeight,
-								srcSet: blockProps.srcSet || undefined,
 							};
-							if ( config.images.useHtmlTag && imageProps.srcSet ) {
+							if ( VipConfig.images.useHtmlTag && imageProps.srcSet ) {
 								return (
 									<img alt={blockProps.alt} {...defaultProps} />
 								);

--- a/next.config.js
+++ b/next.config.js
@@ -124,7 +124,6 @@ module.exports = {
 	// Image Optimization
 	// ==================
 	// https://nextjs.org/docs/basic-features/image-optimization
-	// https://nextjs.org/docs/api-reference/next/image
 	//
 	// The next/image, is an extension of the HTML <img> element, evolved for
 	// the modern web. It includes a variety of built-in performance

--- a/next.config.js
+++ b/next.config.js
@@ -132,11 +132,13 @@ module.exports = {
 		// These widths are used when the next/image component uses layout="responsive"
 		// or layout="fill" to ensure the correct image is served for user's device.
 		deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
-		//
 		// The reason there are two separate lists is that imageSizes is only used
 		// for images which provide a sizes prop, which indicates that the image
 		// is less than the full width of the screen. Therefore, the sizes in
 		// imageSizes should all be smaller than the smallest size in deviceSizes.
 		imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+		// If you want to force usage of the <img /> tag instead of the next/image
+		// element, you should set useHtmlTag option to true.
+		useHtmlTag: false,
 	},
 };

--- a/next.config.js
+++ b/next.config.js
@@ -123,6 +123,9 @@ module.exports = {
 
 	// Image Optimization
 	// ==================
+	// https://nextjs.org/docs/basic-features/image-optimization
+	// https://nextjs.org/docs/api-reference/next/image
+	//
 	// The next/image, is an extension of the HTML <img> element, evolved for
 	// the modern web. It includes a variety of built-in performance
 	// optimizations to help you achieve good Core Web Vitals.
@@ -137,8 +140,5 @@ module.exports = {
 		// is less than the full width of the screen. Therefore, the sizes in
 		// imageSizes should all be smaller than the smallest size in deviceSizes.
 		imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
-		// If you want to force usage of the <img /> tag instead of the next/image
-		// element, you should set useHtmlTag option to true.
-		useHtmlTag: false,
 	},
 };

--- a/vip.config.js
+++ b/vip.config.js
@@ -8,9 +8,12 @@ module.exports = {
 	// Images
 	// ======
 	// https://developer.wordpress.org/apis/handbook/responsive-images/
+	//
 	// By default, WordPress returns for all images the srcSet attribute.
 	// srcSet is an HTML attribute to specify image resources on responsive websites
 	// that use appropriate images for each rendering situation.
+	//
+	// https://nextjs.org/docs/api-reference/next/image
 	//
 	// The next/image, is an extension of the HTML <img> element, evolved for
 	// the modern web. It includes a variety of built-in performance

--- a/vip.config.js
+++ b/vip.config.js
@@ -1,0 +1,23 @@
+// vip.config.js
+// ==============
+// IMPORTANT: vip.config.js is not parsed by Webpack, Babel, or Typescript.
+// Avoid language features that are not available in your target Node.js version.
+// Do not change the file extenstion to .ts.
+//
+module.exports = {
+	// Images
+	// ======
+	// https://developer.wordpress.org/apis/handbook/responsive-images/
+	// By default, WordPress returns for all images the srcSet attribute.
+	// srcSet is an HTML attribute to specify image resources on responsive websites
+	// that use appropriate images for each rendering situation.
+	//
+	// The next/image, is an extension of the HTML <img> element, evolved for
+	// the modern web. It includes a variety of built-in performance
+	// optimizations to help you achieve good Core Web Vitals.
+	images: {
+		// If you want to force usage of the <img /> tag instead of the next/image
+		// element, you should set useHtmlTag option to true.
+		useHtmlTag: false,
+	},
+};


### PR DESCRIPTION
## Summary

- Added the `<img />` component instead of next/image when using `srcSet`
- It has been added on PostContent file, to be used on Group Blocks.

## Notes

- Added the `@next/next/no-img-element` on the eslint rules, because was getting an error to don't use the `<img />` tag.
- `components/PostContent/PostContent.tsx` line 27 was added to prevent warning on if statement.