### PR TITLE
Demonstrate supporting a new block

### DIFF
--- a/components/PostContent/PostContent.tsx
+++ b/components/PostContent/PostContent.tsx
@@ -68,7 +68,7 @@ export default function PostContent( props: {
 								large: blockProps.className || undefined,
 							}
 							return (
-								<Quote 
+								<Quote
 									innerHTML={block.innerHTML}
 									{...quoteProps}
 								/>

--- a/components/PostContent/PostContent.tsx
+++ b/components/PostContent/PostContent.tsx
@@ -64,7 +64,7 @@ export default function PostContent( props: {
 						case 'core/quote':
 							const quoteProps = {
 								...defaultProps,
-								large: blockProps.className || undefined,
+								className: blockProps.className || undefined,
 							}
 							return (
 								<Quote

--- a/components/PostContent/PostContent.tsx
+++ b/components/PostContent/PostContent.tsx
@@ -8,7 +8,6 @@ import Image from '@/components/Image/Image';
 import UnsupportedBlock from '@/components/UnsupportedBlock/UnsupportedBlock';
 import { ContentBlock } from '@/graphql/generated';
 import { mapAttributesToProps } from '@/lib/blocks';
-import { QueryDocumentKeys } from 'graphql/language/visitor';
 
 export default function PostContent( props: {
 	blocks: ContentBlock[],

--- a/components/PostContent/PostContent.tsx
+++ b/components/PostContent/PostContent.tsx
@@ -2,11 +2,13 @@ import VipConfig from '../../vip.config';
 import ClassicEditorBlock from '@/components/ClassicEditorBlock/ClassicEditorBlock';
 import Heading from '@/components/Heading/Heading';
 import Paragraph from '@/components/Paragraph/Paragraph';
+import Quote from '@/components/Quote/Quote';
 import List from '@/components/List/List';
 import Image from '@/components/Image/Image';
 import UnsupportedBlock from '@/components/UnsupportedBlock/UnsupportedBlock';
 import { ContentBlock } from '@/graphql/generated';
 import { mapAttributesToProps } from '@/lib/blocks';
+import { QueryDocumentKeys } from 'graphql/language/visitor';
 
 export default function PostContent( props: {
 	blocks: ContentBlock[],
@@ -59,6 +61,18 @@ export default function PostContent( props: {
 									{...defaultProps}
 								/>
 							);
+
+						case 'core/quote':
+							const quoteProps = {
+								...defaultProps,
+								large: blockProps.className || undefined,
+							}
+							return (
+								<Quote 
+									innerHTML={block.innerHTML}
+									{...quoteProps}
+								/>
+							)
 
 						case 'core/list':
 							return (

--- a/components/Quote/Quote.module.css
+++ b/components/Quote/Quote.module.css
@@ -1,4 +1,3 @@
-.largecontainer,
 .container {
 	margin: 1em 0;
 	padding: 1em;
@@ -6,23 +5,24 @@
     color: gray;
 }
 
-.largecontainer p {
-    font-size: 3rem;
-}
-
 .container cite,
 .container p {
     display: inline;
 }
 
-.largecontainer cite {
-    display: block;
-    text-align: right;
-}
-
-.largecontainer cite:before,
 .container cite:before {
     padding-right: 0.5em;
     padding-left: 2em;
     content: ' \2014 ';
+}
+
+/* Override the default styles: */
+
+.large p {
+    font-size: 3rem;
+}
+
+.large cite {
+    display: block;
+    text-align: right;
 }

--- a/components/Quote/Quote.module.css
+++ b/components/Quote/Quote.module.css
@@ -9,11 +9,20 @@
 .largecontainer p {
     font-size: 3rem;
 }
+
+.container cite,
 .container p {
-    color: green;
+    display: inline;
 }
-.largecontainer cite,
-.container cite {
-    text-align: right;
+
+.largecontainer cite {
     display: block;
+    text-align: right;
+}
+
+.largecontainer cite:before,
+.container cite:before {
+    padding-right: 0.5em;
+    padding-left: 2em;
+    content: ' \2014 ';
 }

--- a/components/Quote/Quote.module.css
+++ b/components/Quote/Quote.module.css
@@ -1,0 +1,19 @@
+.largecontainer,
+.container {
+	margin: 1em 0;
+	padding: 1em;
+    border-left-style: outset;
+    color: gray;
+}
+
+.largecontainer p {
+    font-size: 3rem;
+}
+.container p {
+    color: green;
+}
+.largecontainer cite,
+.container cite {
+    text-align: right;
+    display: block;
+}

--- a/components/Quote/Quote.module.css
+++ b/components/Quote/Quote.module.css
@@ -13,7 +13,7 @@
 .container cite:before {
     padding-right: 0.5em;
     padding-left: 2em;
-    content: ' \2014 ';
+    content: '—'; /* emdash */
 }
 
 /* Override the default styles: */

--- a/components/Quote/Quote.module.css
+++ b/components/Quote/Quote.module.css
@@ -1,6 +1,6 @@
 .container {
-	margin: 1em 0;
-	padding: 1em;
+    margin: 1em 0;
+    padding: 1em;
     border-left-style: outset;
     color: gray;
 }

--- a/components/Quote/Quote.tsx
+++ b/components/Quote/Quote.tsx
@@ -6,8 +6,10 @@ type Props = {
 };
 
 export default function Quote ( props: Props ) {
-	return <p 
-        className={props.large == 'is-style-large' ? styles.largecontainer : styles.container}
-        dangerouslySetInnerHTML={ { __html: props.innerHTML } } 
-    />;
+	return (
+		<blockquote
+			className={props.large == 'is-style-large' ? styles.largecontainer : styles.container}
+			dangerouslySetInnerHTML={ { __html: props.innerHTML } }
+		/>
+	);
 }

--- a/components/Quote/Quote.tsx
+++ b/components/Quote/Quote.tsx
@@ -23,13 +23,13 @@ import styles from './Quote.module.css';
 
 type Props = {
 	innerHTML: string,
-    large?: string,
+	large?: string,
 };
 
 export default function Quote ( props: Props ) {
 	return (
 		<blockquote
-			className={props.large == 'is-style-large' ? styles.largecontainer : styles.container}
+			className={ props.large == 'is-style-large' ? styles.largecontainer : styles.container }
 			dangerouslySetInnerHTML={ { __html: props.innerHTML } }
 		/>
 	);

--- a/components/Quote/Quote.tsx
+++ b/components/Quote/Quote.tsx
@@ -1,24 +1,31 @@
 import styles from './Quote.module.css';
 
 /**
- * This is a styled component.
+ * This is a styled component, for the [Gutenberg Quote Block](https://gogutenberg.com/blocks/quote/).
  *
  * The WordPress block will have content (passed as innerHTML):
  *      <p>Before software can be reusable, it first has to be usable.</p><cite>Ralph Johnson</cite>
- * And a className attribute that is either is-style-default or is-style-large
+ * And a className attribute that is (by default) either is-style-default or is-style-large
  *
- * The PostContent.tsx will set the large prop to the className and deliver the innerHTML as is.
+ * The PostContent.tsx case for Quote will ensure both innerHTML and className are part of the props
  *
  * The Quote component is output as:
  *      <blockquote>
  *          <p>Before software can be reusable, it first has to be usable.</p><cite>Ralph Johnson</cite>
  *      </blockquote>
  *
- * The className varies, and refers to the imported styles in Quote.module.css
+ * The className varies, but should start with is-style-, so we just grab the rest and use a switch statement
+ * to assign the appropriate override style that is imported from Quote.module.css. The .container style is
+ * our default styling and catch-all that should work even if there's no className.
  *
- * Quote.module.css contains two different styling options - large or default.
+ * Quote.module.css contains two different styling options - base/default (the .container class) and large (the .large class).
+ * 
  * The large option results in a defined separation vertically between quote and citation, while the default
  * is much more compact.
+ * 
+ * Since the style can be extended/customized within WordPress, the code here assumes there may be 
+ * other classNames -- but only supports the two current options. If additional classNames can be selected
+ * from the WP admin UI, then declare the related styles in the CSS file and add a case statement for that style.
  */
 
 type Props = {
@@ -27,9 +34,23 @@ type Props = {
 };
 
 export default function Quote ( props: Props ) {
+	// assign 'large', 'default', or something else to classVersion (the Quote style)
+	const classVersion = props.className ? props.className.substring(9) : 'default';
+	let style = styles.container;
+
+	switch ( classVersion ) {
+		case 'large': 
+			style +=  ' ' + styles.large;
+			break;
+		// Add additional styles here
+		case 'default':
+		default:
+			// no additional class
+	}
+
 	return (
 		<blockquote
-			className={ props.large == 'is-style-large' ? styles.largecontainer : styles.container }
+			className={ style }
 			dangerouslySetInnerHTML={ { __html: props.innerHTML } }
 		/>
 	);

--- a/components/Quote/Quote.tsx
+++ b/components/Quote/Quote.tsx
@@ -31,7 +31,7 @@ import styles from './Quote.module.css';
 
 type Props = {
 	innerHTML: string,
-	large?: string,
+	className?: string,
 };
 
 export default function Quote ( props: Props ) {

--- a/components/Quote/Quote.tsx
+++ b/components/Quote/Quote.tsx
@@ -1,0 +1,13 @@
+import styles from './Quote.module.css';
+
+type Props = {
+	innerHTML: string,
+    large?: string,
+};
+
+export default function Quote ( props: Props ) {
+	return <p 
+        className={props.large == 'is-style-large' ? styles.largecontainer : styles.container}
+        dangerouslySetInnerHTML={ { __html: props.innerHTML } } 
+    />;
+}

--- a/components/Quote/Quote.tsx
+++ b/components/Quote/Quote.tsx
@@ -1,7 +1,8 @@
 import styles from './Quote.module.css';
 
 /**
- * This is a styled component, for the [Gutenberg Quote Block](https://gogutenberg.com/blocks/quote/).
+ * This is a styled component, for the Gutenberg Quote Block
+ * (Block documentation: https://gogutenberg.com/blocks/quote/)
  *
  * The WordPress block will have content (passed as innerHTML):
  *      <p>Before software can be reusable, it first has to be usable.</p><cite>Ralph Johnson</cite>

--- a/components/Quote/Quote.tsx
+++ b/components/Quote/Quote.tsx
@@ -1,5 +1,26 @@
 import styles from './Quote.module.css';
 
+/**
+ * This is a styled component.
+ *
+ * The WordPress block will have content (passed as innerHTML):
+ *      <p>Before software can be reusable, it first has to be usable.</p><cite>Ralph Johnson</cite>
+ * And a className attribute that is either is-style-default or is-style-large
+ *
+ * The PostContent.tsx will set the large prop to the className and deliver the innerHTML as is.
+ *
+ * The Quote component is output as:
+ *      <blockquote>
+ *          <p>Before software can be reusable, it first has to be usable.</p><cite>Ralph Johnson</cite>
+ *      </blockquote>
+ *
+ * The className varies, and refers to the imported styles in Quote.module.css
+ *
+ * Quote.module.css contains two different styling options - large or default.
+ * The large option results in a defined separation vertically between quote and citation, while the default
+ * is much more compact.
+ */
+
 type Props = {
 	innerHTML: string,
     large?: string,


### PR DESCRIPTION
This demonstrates supporting the [WordPress core Quote block](https://gogutenberg.com/blocks/quote/):
- handling it (minimally) in the PostContent.tsx switch statement
- implementing the actual Quote component
- using module styling for the component
- applying a default and a large style, and opening it up to future additional options

The quote block in the WordPress editor:
![image](https://user-images.githubusercontent.com/294707/150872173-b2262a69-2579-4158-859a-4ed5bf67986a.png)

The default quote block in the Next.js rendered page:
![image](https://user-images.githubusercontent.com/294707/150872253-3106d068-4a20-4c69-8a18-2e51cd952171.png)

The large option:
![image](https://user-images.githubusercontent.com/294707/150872305-de1b3ab5-eeed-481a-8d22-eba1f21f8a65.png)
