### PR TITLE
Reenable GitHub actions and add additional linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,16 @@
 {
+	"env": {
+		"jest/globals": true
+	},
 	"extends": [
+		"eslint:recommended",
+		"plugin:jest/recommended",
 		"next",
 		"next/core-web-vitals"
+	],
+	"plugins": [
+		"editorconfig",
+		"jest"
 	],
 	"rules": {
 		"indent": [ "error", "tab", { "SwitchCase": 1 } ],

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,8 @@
 	},
 	"extends": [
 		"eslint:recommended",
+		"plugin:@typescript-eslint/eslint-recommended",
+		"plugin:@typescript-eslint/recommended",
 		"plugin:jest/recommended",
 		"next",
 		"next/core-web-vitals"
@@ -13,7 +15,11 @@
 		"jest"
 	],
 	"rules": {
-		"indent": [ "error", "tab", { "SwitchCase": 1 } ],
-		"@next/next/no-img-element": "off"
+		"@typescript-eslint/ban-ts-comment": [
+			2,
+			{
+				"ts-expect-error": "allow-with-description"
+			}
+		]
 	}
 }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,9 @@
 name: Lint
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
-      - main
+      - trunk
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,9 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
-      - main
+      - trunk
 
 jobs:
   build:

--- a/components/ClientOnly/ClientOnly.tsx
+++ b/components/ClientOnly/ClientOnly.tsx
@@ -3,7 +3,7 @@ import { ReactNode, useEffect, useState } from 'react';
 export default function ClientOnly( props: {
 	children: ReactNode,
 } ) {
-	const [ hasMounted, setHasMounted ] = useState<Boolean>( false );
+	const [ hasMounted, setHasMounted ] = useState<boolean>( false );
 
 	useEffect( () => {
 		setHasMounted( true );

--- a/components/Image/Image.tsx
+++ b/components/Image/Image.tsx
@@ -32,7 +32,7 @@ export default function Image ( props: Props ) {
 		src: props.src,
 		width: props.width || props.originalWidth,
 		height: props.height || props.originalHeight,
-		layout: props.width ? 'fixed' as any : 'responsive' as any,
+		layout: props.width ? 'fixed' as const : 'responsive' as const,
 	};
 
 	if ( VipConfig.images.useHtmlTag && imageProps.srcSet ) {

--- a/components/PostContent/PostContent.tsx
+++ b/components/PostContent/PostContent.tsx
@@ -54,14 +54,11 @@ export default function PostContent( props: {
 							);
 
 						case 'core/quote':
-							const quoteProps = {
-								...defaultProps,
-								className: blockProps.className || undefined,
-							}
 							return (
 								<Quote
+									{...defaultProps}
+									className={blockProps.className || undefined}
 									innerHTML={block.innerHTML}
-									{...quoteProps}
 								/>
 							)
 

--- a/graphql/apollo-link.ts
+++ b/graphql/apollo-link.ts
@@ -1,10 +1,10 @@
 import { ApolloLink, HttpLink, from } from '@apollo/client';
 import { onError } from '@apollo/client/link/error';
-import { log, logError } from '@/lib/log';
+import { log, logError, LogContext } from '@/lib/log';
 
 const uri = process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT;
 
-export default function getApolloLink ( requestContext: any = {} ) {
+export default function getApolloLink ( requestContext: LogContext = {} ) {
 	// If endpoint is undefined, throw for visibility.
 	if ( 'undefined' === typeof uri ) {
 		throw new Error( 'GraphQL endpoint is undefined' );

--- a/graphql/apollo.ts
+++ b/graphql/apollo.ts
@@ -3,7 +3,7 @@ import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
 import fragmentMatcher from '@/graphql/generated/fragmentMatcher';
 import getApolloLink from './apollo-link';
 
-let clientSideApolloClient: ApolloClient<any>;
+let clientSideApolloClient: ApolloClient<unknown>;
 
 const isServerSide = 'undefined' === typeof window;
 
@@ -27,7 +27,7 @@ const { possibleTypes } = fragmentMatcher;
 export default function getApolloClient ( serverSideContext?: GetServerSidePropsContext | GetStaticPropsContext ) {
 	// Server-side / static: Return a new instance every time.
 	if ( isServerSide ) {
-		// @ts-ignore: Express locals are not defined on Next.js request.
+		// @ts-expect-error: Express locals are not defined on Next.js request.
 		const { requestContext } = serverSideContext?.res?.locals || {};
 
 		return new ApolloClient( {

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -48,7 +48,7 @@ export function getHostname ( url: string ): string {
 		const { hostname } = new URL( url );
 
 		return hostname;
-	} catch ( err ) {}
+	} catch ( err ) { /* continue */ }
 
 	return url;
 }
@@ -61,7 +61,7 @@ export function getInternalLinkPathname ( url: string ): string {
 		if ( [ 'http:', 'https:' ].includes( protocol ) && internalLinkHostnames.includes( hostname ) ) {
 			return `${getCorrectPathname( pathname )}${search}`;
 		}
-	} catch ( err ) {}
+	} catch ( err ) { /* continue */ }
 
 	return url;
 }

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -5,7 +5,7 @@ enum LogLevel {
 	ERROR = 'ERROR',
 }
 
-type LogContext = {
+export type LogContext = {
 	[ key: string ]: string | number,
 };
 

--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -1,7 +1,7 @@
 import getRedisClient from './client';
 import { log } from '@/lib/log';
 
-export async function getCacheObjectByKey( key: string, ttl: number, fallback: () => Promise<any> ) {
+export async function getCacheObjectByKey<T>( key: string, ttl: number, fallback: () => Promise<T> ) {
 	const redisClient = getRedisClient();
 
 	function logRedisEvent ( message: string ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1682,6 +1682,12 @@
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
       "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA=="
     },
+    "@types/json-schema": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "dev": true
+    },
     "@types/json-stable-stringify": {
       "version": "1.0.33",
       "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.33.tgz",
@@ -1774,6 +1780,60 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.2.tgz",
+      "integrity": "sha512-4W/9lLuE+v27O/oe7hXJKjNtBLnZE8tQAFpapdxwSVHqtmIoPB1gph3+ahNwVuNL37BX7YQHyGF9Xv6XCnIX2Q==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "5.10.2",
+        "@typescript-eslint/type-utils": "5.10.2",
+        "@typescript-eslint/utils": "5.10.2",
+        "debug": "^4.3.2",
+        "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.10.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.2.tgz",
+          "integrity": "sha512-39Tm6f4RoZoVUWBYr3ekS75TYgpr5Y+X0xLZxXqcZNDWZdJdYbKd3q2IR4V9y5NxxiPu/jxJ8XP7EgHiEQtFnw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.10.2",
+            "@typescript-eslint/visitor-keys": "5.10.2"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.10.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.2.tgz",
+          "integrity": "sha512-Qfp0qk/5j2Rz3p3/WhWgu4S1JtMcPgFLnmAKAW061uXxKSa7VWKZsDXVaMXh2N60CX9h6YLaBoy9PJAfCOjk3w==",
+          "dev": true
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.10.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.2.tgz",
+          "integrity": "sha512-zHIhYGGGrFJvvyfwHk5M08C5B5K4bewkm+rrvNTKk1/S15YHR+SA/QUF8ZWscXSfEaB8Nn2puZj+iHcoxVOD/Q==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.10.2",
+            "eslint-visitor-keys": "^3.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "@typescript-eslint/parser": {
       "version": "5.10.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
@@ -1794,6 +1854,17 @@
       "requires": {
         "@typescript-eslint/types": "5.10.1",
         "@typescript-eslint/visitor-keys": "5.10.1"
+      }
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.2.tgz",
+      "integrity": "sha512-uRKSvw/Ccs5FYEoXW04Z5VfzF2iiZcx8Fu7DGIB7RHozuP0VbKNzP1KfZkHBTM75pCpsWxIthEH1B33dmGBKHw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "5.10.2",
+        "debug": "^4.3.2",
+        "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
@@ -1817,6 +1888,97 @@
         "tsutils": "^3.21.0"
       },
       "dependencies": {
+        "is-glob": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.2.tgz",
+      "integrity": "sha512-vuJaBeig1NnBRkf7q9tgMLREiYD7zsMrsN1DA3wcoMDvr3BTFiIpKjGiYZoKPllfEwN7spUjv7ZqD+JhbVjEPg==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.10.2",
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/typescript-estree": "5.10.2",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.10.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.2.tgz",
+          "integrity": "sha512-39Tm6f4RoZoVUWBYr3ekS75TYgpr5Y+X0xLZxXqcZNDWZdJdYbKd3q2IR4V9y5NxxiPu/jxJ8XP7EgHiEQtFnw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.10.2",
+            "@typescript-eslint/visitor-keys": "5.10.2"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.10.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.2.tgz",
+          "integrity": "sha512-Qfp0qk/5j2Rz3p3/WhWgu4S1JtMcPgFLnmAKAW061uXxKSa7VWKZsDXVaMXh2N60CX9h6YLaBoy9PJAfCOjk3w==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.10.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.2.tgz",
+          "integrity": "sha512-WHHw6a9vvZls6JkTgGljwCsMkv8wu8XU8WaYKeYhxhWXH/atZeiMW6uDFPLZOvzNOGmuSMvHtZKd6AuC8PrwKQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.10.2",
+            "@typescript-eslint/visitor-keys": "5.10.2",
+            "debug": "^4.3.2",
+            "globby": "^11.0.4",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.10.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.2.tgz",
+          "integrity": "sha512-zHIhYGGGrFJvvyfwHk5M08C5B5K4bewkm+rrvNTKk1/S15YHR+SA/QUF8ZWscXSfEaB8Nn2puZj+iHcoxVOD/Q==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.10.2",
+            "eslint-visitor-keys": "^3.0.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "dev": true
+        },
         "is-glob": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2662,6 +2824,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
     "common-tags": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -3055,6 +3223,36 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3436,6 +3634,18 @@
         }
       }
     },
+    "eslint-plugin-editorconfig": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-editorconfig/-/eslint-plugin-editorconfig-3.2.0.tgz",
+      "integrity": "sha512-XiUg69+qgv6BekkPCjP8+2DMODzPqtLV5i0Q9FO1v40P62pfodG1vjIihVbw/338hS5W26S+8MTtXaAlrg37QQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "editorconfig": "^0.15.0",
+        "eslint": "^8.0.1",
+        "klona": "^2.0.4"
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.25.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
@@ -3490,6 +3700,15 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.0.0.tgz",
+      "integrity": "sha512-Fvs0YgJ/nw9FTrnqTuMGVrkozkd07jkQzWm0ajqyHlfcsdkxGfAuv30fgfWHOnHiCr9+1YQ365CcDX7vrNhqQg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "^5.10.0"
       }
     },
     "eslint-plugin-jsx-a11y": {
@@ -5566,6 +5785,12 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "klona": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
+      "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
+      "dev": true
+    },
     "language-subtag-registry": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
@@ -6644,6 +6869,12 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -7167,6 +7398,12 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "@types/jest": "27.4.0",
     "eslint": "8.8.0",
     "eslint-config-next": "12.0.9",
+    "eslint-plugin-editorconfig": "^3.2.0",
+    "eslint-plugin-jest": "^26.0.0",
     "jest": "27.4.7",
     "ts-jest": "27.1.3"
   }

--- a/pages/api/books.ts
+++ b/pages/api/books.ts
@@ -31,7 +31,7 @@ export default async function handler( req: NextApiRequest, res: NextApiResponse
 		const response = await fetch( url );
 
 		return response.json();
-	};
+	}
 
 	try {
 		const book = await getCacheObjectByKey( cacheKey, ttl, fallback );

--- a/pages/api/books.ts
+++ b/pages/api/books.ts
@@ -7,7 +7,7 @@ import { getCacheObjectByKey } from '@/lib/redis';
  * Find out if the Internet Archive has a book.
  */
 export default async function handler( req: NextApiRequest, res: NextApiResponse ) {
-	// @ts-ignore: Express locals are not defined on Next.js request.
+	// @ts-expect-error: Express locals are not defined on Next.js request.
 	const { requestContext } = res.locals;
 
 	// Don Quixote (Penguin Classics, English)

--- a/pages/api/robots.ts
+++ b/pages/api/robots.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { publicEndpoint } from '@/lib/config';
 
-let robotsTxt = `
+const robotsTxt = `
 User-agent: *
 
 Allow: *

--- a/pages/preview/[token]/[id].tsx
+++ b/pages/preview/[token]/[id].tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { GetServerSideProps } from 'next';
 import { FetchPolicy } from '@apollo/client';
 import getApolloClient from '@/graphql/apollo';

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@
 // Avoid language features that are not available in your target Node.js version.
 // Do not change the file extenstion to .ts.
 
+/* eslint-disable @typescript-eslint/no-var-requires */
 require( 'dotenv' ).config();
 const express = require( 'express' );
 const { createProxyMiddleware } = require( 'http-proxy-middleware' );


### PR DESCRIPTION
The GitHub actions had stopped running due to the default branch change.

Taking the opportunity to add some lint rules around TypeScript and Jest. I also added a plugin to enforce `.editorconfig` (whitespace consistency), but will commit the fixes in a separate PR.