### PR TITLE
Avoid createElement and add BlockProps interface

### DIFF
--- a/components/Blocks/ClassicEditorBlock/ClassicEditorBlock.tsx
+++ b/components/Blocks/ClassicEditorBlock/ClassicEditorBlock.tsx
@@ -1,9 +1,5 @@
-import { ContentBlock } from '@/graphql/generated';
+import { BlockProps } from '../index';
 
-type Props = {
-	block: ContentBlock,
-};
-
-export default function ClassicEditorBlock ( { block: { innerHTML } } : Props ) {
+export default function ClassicEditorBlock ( { block: { innerHTML } }: BlockProps ) {
 	return <div dangerouslySetInnerHTML={ { __html: innerHTML } } />;
 }

--- a/components/Blocks/Heading/Heading.tsx
+++ b/components/Blocks/Heading/Heading.tsx
@@ -1,9 +1,5 @@
-import { ContentBlock } from '@/graphql/generated';
+import { BlockProps } from '../index';
 
-type Props = {
-	block: ContentBlock,
-};
-
-export default function Heading ( { block: { innerHTML } }: Props ) {
+export default function Heading ( { block: { innerHTML } }: BlockProps ) {
 	return <h3 dangerouslySetInnerHTML={ { __html: innerHTML } } />;
 }

--- a/components/Blocks/ImageBlock/ImageBlock.tsx
+++ b/components/Blocks/ImageBlock/ImageBlock.tsx
@@ -1,8 +1,7 @@
+import { BlockProps } from '../index';
 import Image from '@/components/Image/Image';
-import { ContentBlock } from '@/graphql/generated';
 
-type Props = {
-	block: ContentBlock,
+type Props = BlockProps & {
 	src: string,
 	alt: string,
 };

--- a/components/Blocks/List/List.tsx
+++ b/components/Blocks/List/List.tsx
@@ -1,7 +1,6 @@
-import { ContentBlock } from '@/graphql/generated';
+import { BlockProps } from '../index';
 
-type Props = {
-	block: ContentBlock,
+type Props = BlockProps & {
 	ordered?: boolean,
 	reversed?: boolean,
 	start?: number,

--- a/components/Blocks/Paragraph/Paragraph.tsx
+++ b/components/Blocks/Paragraph/Paragraph.tsx
@@ -1,9 +1,5 @@
-import { ContentBlock } from '@/graphql/generated';
+import { BlockProps } from '../index';
 
-type Props = {
-	block: ContentBlock,
-};
-
-export default function Paragraph ( { block: { innerHTML } } : Props ) {
+export default function Paragraph ( { block: { innerHTML } }: BlockProps ) {
 	return <p dangerouslySetInnerHTML={ { __html: innerHTML } } />;
 }

--- a/components/Blocks/Quote/Quote.tsx
+++ b/components/Blocks/Quote/Quote.tsx
@@ -1,5 +1,4 @@
-import { ContentBlock } from '@/graphql/generated';
-
+import { BlockProps } from '../index';
 import styles from './Quote.module.css';
 
 /**
@@ -31,8 +30,7 @@ import styles from './Quote.module.css';
  * from the WP admin UI, then declare the related styles in the CSS file and add a case statement for that style.
  */
 
-type Props = {
-	block: ContentBlock,
+type Props = BlockProps & {
 	className?: string,
 };
 

--- a/components/Blocks/Table/Table.tsx
+++ b/components/Blocks/Table/Table.tsx
@@ -1,10 +1,6 @@
-import { ContentBlock } from '@/graphql/generated';
+import { BlockProps } from '../index';
 
-type Props = {
-	block: ContentBlock,
-};
-
-export default function Table ( { block: { innerHTML }, ...props } : Props ) {
+export default function Table ( { block: { innerHTML }, ...props }: BlockProps ) {
 	return (
 		<table
 			cellPadding={ 0 }

--- a/components/Blocks/UnsupportedBlock/UnsupportedBlock.tsx
+++ b/components/Blocks/UnsupportedBlock/UnsupportedBlock.tsx
@@ -1,11 +1,7 @@
-import { ContentBlock } from '@/graphql/generated';
+import { BlockProps } from '../index';
 import styles from './UnsupportedBlock.module.css';
 
-type Props = {
-	block: ContentBlock,
-};
-
-export default function UnsupportedBlock ( { block: { name, tagName, attributes, innerBlocks, outerHTML } } : Props ) {
+export default function UnsupportedBlock ( { block: { name, tagName, attributes, innerBlocks, outerHTML } }: BlockProps ) {
 	const html = outerHTML;
 
 	return (

--- a/components/Blocks/index.tsx
+++ b/components/Blocks/index.tsx
@@ -1,4 +1,5 @@
-import { ReactNode } from 'react';
+import { ComponentType } from 'react';
+import { ContentBlock } from '@/graphql/generated';
 import ClassicEditorBlock from './ClassicEditorBlock/ClassicEditorBlock';
 import Heading from './Heading/Heading';
 import ImageBlock from './ImageBlock/ImageBlock';
@@ -6,11 +7,16 @@ import List from './List/List';
 import Paragraph from './Paragraph/Paragraph';
 import Quote from './Quote/Quote';
 import Table from './Table/Table';
-import UnsupportedBlock from './UnsupportedBlock/UnsupportedBlock';
 
-type BlocksToComponentsProps = Record<string, ReactNode>;
+export interface BlockProps {
+	block: ContentBlock,
+}
 
-const defaultBlockMap : BlocksToComponentsProps = {
+export type PostContentBlockMap = {
+	[ key: string ]: ComponentType<BlockProps>;
+};
+
+const defaultBlockMap: PostContentBlockMap = {
 	'core/classic-editor': ClassicEditorBlock,
 	'core/heading': Heading,
 	'core/image': ImageBlock,
@@ -18,7 +24,6 @@ const defaultBlockMap : BlocksToComponentsProps = {
 	'core/paragraph': Paragraph,
 	'core/quote': Quote,
 	'core/table': Table,
-	'unsupported': UnsupportedBlock,
-}
+};
 
 export default defaultBlockMap;

--- a/components/PostContent/PostContent.tsx
+++ b/components/PostContent/PostContent.tsx
@@ -1,22 +1,20 @@
-import { createElement } from 'react';
 import { ContentBlock } from '@/graphql/generated';
 import { mapAttributesToProps } from '@/lib/blocks';
-import defaultBlockMap from '@/components/Blocks/index';
-
-type BlocksToComponentsProps = typeof defaultBlockMap;
+import defaultBlockMap, { PostContentBlockMap } from '@/components/Blocks';
+import UnsupportedBlock from '@/components/Blocks/UnsupportedBlock/UnsupportedBlock';
 
 type Props = {
 	blocks: ContentBlock[],
-	blockMapOverrides?: BlocksToComponentsProps,
+	blockMapOverrides?: PostContentBlockMap,
 };
 
-export default function PostContent( { blocks, blockMapOverrides = {  } } : Props ) {
+export default function PostContent( { blocks, blockMapOverrides = {} } : Props ) {
 	// This is a functional component used to render the related component for each block on PostContent
 	//
 	// If you want to customize some component or create new ones, you can provide the blockMapOverrides prop to this component
 	// with a mapping when you're rendering some page on next.js structure.
 	//
-	const blockMap : BlocksToComponentsProps = {
+	const blockMap: PostContentBlockMap = {
 		...defaultBlockMap,
 		...blockMapOverrides,
 	};
@@ -27,21 +25,16 @@ export default function PostContent( { blocks, blockMapOverrides = {  } } : Prop
 				blocks.map( ( block, i ) => {
 					const attributesProps = mapAttributesToProps( block.attributes || [] );
 					const defaultProps = { key: `block-${i}`, block };
-					const Component = blockMap[ block.name ];
+					const Block = blockMap[ block.name ];
 
-					if ( Component ) {
-						return createElement(
-							Component as string,
-							{ ...defaultProps, ...attributesProps },
-						);
+					if ( Block ) {
+						return <Block {...defaultProps} {...attributesProps } />;
+					}
 
 					// In development, highlight unsupported blocks so that they get
 					// visibility with developers.
-					} else if ( 'development' === process.env.NODE_ENV ) {
-						return createElement(
-							blockMap[ 'unsupported' ] as string,
-							defaultProps,
-						);
+					if ( 'development' === process.env.NODE_ENV ) {
+						return <UnsupportedBlock {...defaultProps} />;
 					}
 
 					// In production, ignore unsupported blocks.

--- a/lib/blocks.ts
+++ b/lib/blocks.ts
@@ -1,9 +1,13 @@
 import { ContentBlockAttribute } from '@/graphql/generated';
 
+export type PostContentBlockAttributes = {
+	[ key: string ]: string;
+};
+
 /**
  * Map an array of ContentBlock attributes to an object that can used like props.
  */
-function mapAttributesToProps ( attributes: ContentBlockAttribute[] ): { [ key: string ]: string; } {
+export function mapAttributesToProps ( attributes: ContentBlockAttribute[] ): PostContentBlockAttributes {
 	return attributes.reduce( ( acc, { name, value } ) => {
 		// Drop attributes without a name or value.
 		if ( ! name || ! value ) {
@@ -20,7 +24,3 @@ function mapAttributesToProps ( attributes: ContentBlockAttribute[] ): { [ key: 
 		return Object.assign( acc, { [ name ]: value } );
 	}, {} );
 }
-
-export {
-	mapAttributesToProps
-};


### PR DESCRIPTION
- Avoid createElement and return to JSX expression in `PostContent`
- Introduce `BlockProps` interface that can be reused by all Block components
-  Remove `Unsupported` block from block map. Technically a user could name their Gutenberg block `'unsupported'`, which would break our desired behavior.