### PR TITLE
Fix/Image layout using props.layout

### DIFF
--- a/components/Image/Image.tsx
+++ b/components/Image/Image.tsx
@@ -29,7 +29,7 @@ export default function Image ( props: Props ) {
 		alt: props.alt,
 		width: props.width || props.originalWidth,
 		height: props.height || props.originalHeight,
-		layout: props.width ? 'fixed' as const : 'responsive' as const,
+		layout: props.layout || (props.width && props.height ? 'fixed' as const : 'intrinsic' as const),
 	};
 
 	if ( VipConfig.images.useHtmlTag && imageProps.srcSet ) {


### PR DESCRIPTION
## Description

- Fixed issue when Image is setting `layout="fill"` and width/height are `undefined`