### PR TITLE
Add request logs to the template

### DIFF
--- a/graphql/apollo-link.ts
+++ b/graphql/apollo-link.ts
@@ -52,7 +52,6 @@ export default function getApolloLink ( requestContext: LogContext = {} ) {
 
 			return forward( operation )
 				.map( data => {
-
 					const context = {
 						...debug,
 						cacheStatus: operation.getContext().response?.headers?.get( 'x-cache' ),

--- a/graphql/apollo-link.ts
+++ b/graphql/apollo-link.ts
@@ -52,11 +52,12 @@ export default function getApolloLink ( requestContext: LogContext = {} ) {
 
 			return forward( operation )
 				.map( data => {
+					const response = operation.getContext().response;
 					const context = {
 						...debug,
-						cacheStatus: operation.getContext().response?.headers?.get( 'x-cache' ),
-						cacheAge: operation.getContext().response?.headers?.get( 'age' ),
-						payloadSize: operation.getContext().response?.body?.bytesWritten,
+						cacheStatus: response?.headers?.get( 'x-cache' ),
+						cacheAge: response?.headers?.get( 'age' ),
+						payloadSize: response?.body?.bytesWritten,
 						requestDurationInMs: Date.now() - startTime,
 					};
 

--- a/graphql/apollo-link.ts
+++ b/graphql/apollo-link.ts
@@ -43,7 +43,7 @@ export default function getApolloLink ( requestContext: LogContext = {} ) {
 
 			setContext( ( { headers = {} } ) => ( {
 				headers: {
-					...headers,q
+					...headers,
 					// Here is where you can set custom request headers for your GraphQL
 					// requests. If the request is client-side, it must be allowed by the
 					// CORS policy in WPGraphQL.

--- a/graphql/apollo-link.ts
+++ b/graphql/apollo-link.ts
@@ -43,7 +43,7 @@ export default function getApolloLink ( requestContext: LogContext = {} ) {
 
 			setContext( ( { headers = {} } ) => ( {
 				headers: {
-					...headers,
+					...headers,q
 					// Here is where you can set custom request headers for your GraphQL
 					// requests. If the request is client-side, it must be allowed by the
 					// CORS policy in WPGraphQL.
@@ -52,8 +52,19 @@ export default function getApolloLink ( requestContext: LogContext = {} ) {
 
 			return forward( operation )
 				.map( data => {
+					let cacheStatus = operation.getContext().response?.headers?.get('x-cache');
+
+					if (cacheStatus === 'pass') {
+						cacheStatus = 'bypassed';
+					} else if (cacheStatus === 'grace') {
+						cacheStatus = 'refreshing';
+					}
+
 					const context = {
 						...debug,
+						cacheStatus,
+						cacheAge: operation.getContext().response?.headers?.get('age'),
+						payloadSize: operation.getContext().response?.body?.bytesWritten,
 						requestDurationInMs: Date.now() - startTime,
 					};
 

--- a/graphql/apollo-link.ts
+++ b/graphql/apollo-link.ts
@@ -52,18 +52,11 @@ export default function getApolloLink ( requestContext: LogContext = {} ) {
 
 			return forward( operation )
 				.map( data => {
-					let cacheStatus = operation.getContext().response?.headers?.get('x-cache');
-
-					if (cacheStatus === 'pass') {
-						cacheStatus = 'bypassed';
-					} else if (cacheStatus === 'grace') {
-						cacheStatus = 'refreshing';
-					}
 
 					const context = {
 						...debug,
-						cacheStatus,
-						cacheAge: operation.getContext().response?.headers?.get('age'),
+						cacheStatus: operation.getContext().response?.headers?.get( 'x-cache' ),
+						cacheAge: operation.getContext().response?.headers?.get( 'age' ),
 						payloadSize: operation.getContext().response?.body?.bytesWritten,
 						requestDurationInMs: Date.now() - startTime,
 					};

--- a/graphql/apollo.ts
+++ b/graphql/apollo.ts
@@ -35,7 +35,7 @@ export default function getApolloClient ( serverSideContext?: GetServerSideProps
 		// @ts-expect-error: res may not be defined
 		const pathName = serverSideContext?.res?.getHeader('x-request-path');
 
-		// Add the requestID for the original API/Page request to each request's underlying context
+		// Add the requestID for the original API/Page request to each WP query's context
 		if (sourceId) {
 			requestContext = {
 				...requestContext,
@@ -43,7 +43,7 @@ export default function getApolloClient ( serverSideContext?: GetServerSideProps
 			};
 		}
 
-		// Add the path name for the original API/Page request to each request's underlying context
+		// Add the path name for the original API/Page request to each WP query's context
 		if (pathName) {
 			requestContext = {
 				...requestContext,

--- a/graphql/apollo.ts
+++ b/graphql/apollo.ts
@@ -35,6 +35,7 @@ export default function getApolloClient ( serverSideContext?: GetServerSideProps
 		// @ts-expect-error: res may not be defined
 		const pathName = serverSideContext?.res?.getHeader('x-request-path');
 
+		// Add the requestID for the original API/Page request to each request's underlying context
 		if (sourceId) {
 			requestContext = {
 				...requestContext,
@@ -42,6 +43,7 @@ export default function getApolloClient ( serverSideContext?: GetServerSideProps
 			};
 		}
 
+		// Add the path name for the original API/Page request to each request's underlying context
 		if (pathName) {
 			requestContext = {
 				...requestContext,

--- a/graphql/apollo.ts
+++ b/graphql/apollo.ts
@@ -2,6 +2,7 @@ import { ApolloClient, InMemoryCache } from '@apollo/client';
 import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
 import fragmentMatcher from '@/graphql/generated/fragmentMatcher';
 import getApolloLink from './apollo-link';
+import { generateRequestContext } from '@/lib/log';
 
 let clientSideApolloClient: ApolloClient<unknown>;
 
@@ -28,19 +29,7 @@ export default function getApolloClient ( serverSideContext?: GetServerSideProps
 	// Server-side / static: Return a new instance every time.
 	if ( isServerSide ) {
 
-		// @ts-expect-error: Express res may not be defined on Next.js request.
-		const sourceId = serverSideContext?.res?.getHeader('x-source-id') || null;
-		// @ts-expect-error: Express res  may not be defined on Next.js request.
-		const pathName = serverSideContext?.res?.getHeader('x-request-path') || null;
-
-		// @ts-expect-error: Express locals and res may not be defined on Next.js request.
-		let { requestContext } = serverSideContext?.res?.locals || {};
-
-		requestContext = {
-			...requestContext,
-			sourceId,
-			pathName,
-		};
+		const requestContext = generateRequestContext(serverSideContext);
 
 		return new ApolloClient( {
 			cache: new InMemoryCache( { possibleTypes } ),

--- a/graphql/apollo.ts
+++ b/graphql/apollo.ts
@@ -27,29 +27,20 @@ const { possibleTypes } = fragmentMatcher;
 export default function getApolloClient ( serverSideContext?: GetServerSidePropsContext | GetStaticPropsContext ) {
 	// Server-side / static: Return a new instance every time.
 	if ( isServerSide ) {
-		// @ts-expect-error: Express locals are not defined on Next.js request.
+
+		// @ts-expect-error: Express res may not be defined on Next.js request.
+		const sourceId = serverSideContext?.res?.getHeader('x-source-id') || null;
+		// @ts-expect-error: Express res  may not be defined on Next.js request.
+		const pathName = serverSideContext?.res?.getHeader('x-request-path') || null;
+
+		// @ts-expect-error: Express locals and res may not be defined on Next.js request.
 		let { requestContext } = serverSideContext?.res?.locals || {};
 
-		// @ts-expect-error: res may not be defined
-		const sourceId = serverSideContext?.res?.getHeader('x-source-id');
-		// @ts-expect-error: res may not be defined
-		const pathName = serverSideContext?.res?.getHeader('x-request-path');
-
-		// Add the requestID for the original API/Page request to each WP query's context
-		if (sourceId) {
-			requestContext = {
-				...requestContext,
-				sourceId
-			};
-		}
-
-		// Add the path name for the original API/Page request to each WP query's context
-		if (pathName) {
-			requestContext = {
-				...requestContext,
-				pathName
-			};
-		}
+		requestContext = {
+			...requestContext,
+			sourceId,
+			pathName,
+		};
 
 		return new ApolloClient( {
 			cache: new InMemoryCache( { possibleTypes } ),

--- a/graphql/apollo.ts
+++ b/graphql/apollo.ts
@@ -28,7 +28,26 @@ export default function getApolloClient ( serverSideContext?: GetServerSideProps
 	// Server-side / static: Return a new instance every time.
 	if ( isServerSide ) {
 		// @ts-expect-error: Express locals are not defined on Next.js request.
-		const { requestContext } = serverSideContext?.res?.locals || {};
+		let { requestContext } = serverSideContext?.res?.locals || {};
+
+		// @ts-expect-error: res may not be defined
+		const sourceId = serverSideContext?.res?.getHeader('x-source-id');
+		// @ts-expect-error: res may not be defined
+		const pathName = serverSideContext?.res?.getHeader('x-request-path');
+
+		if (sourceId) {
+			requestContext = {
+				...requestContext,
+				sourceId
+			};
+		}
+
+		if (pathName) {
+			requestContext = {
+				...requestContext,
+				pathName
+			};
+		}
 
 		return new ApolloClient( {
 			cache: new InMemoryCache( { possibleTypes } ),

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -1,3 +1,6 @@
+import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
+import { randomUUID } from 'crypto'
+
 enum LogLevel {
 	DEBUG = 'DEBUG',
 	INFO = 'INFO',
@@ -8,6 +11,38 @@ enum LogLevel {
 export type LogContext = {
 	[ key: string ]: string | number,
 };
+
+/**
+ * Generate a new RequestContext that contains the path name that's been requested
+ * along with the requestID that's added onto the request by the Automattic infrastructure.
+ *
+ * In the event that no requestID is found, such as during local development, a UUID is
+ * generated instead in the form of local-UUID. A new one will be generated each time
+ * this method is called.
+ *
+ * This is scoped to a request, and is meant for populating the requestContext for server side
+ * requests to non-static resources.
+ */
+export function generateRequestContext( serverSideContext?: GetServerSidePropsContext |
+GetStaticPropsContext ) {
+	let requestContext: LogContext = { };
+
+	if (( 'undefined' === typeof window ) && (( serverSideContext as GetServerSidePropsContext ).req !== undefined )) {
+		const { req } = serverSideContext as GetServerSidePropsContext;
+
+		const sourceId = req.headers[ 'x-request-id' ] || `local-${ randomUUID() }`;
+		const pathName = req.url;
+
+		requestContext = {
+			sourceId: `${ sourceId }`,
+			pathName,
+		};
+
+		log( 'RequestContext has been generated', {}, requestContext );
+	}
+
+	return requestContext;
+}
 
 export function log(
 	message: string,

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -15,13 +15,7 @@ export function log(
 	requestContext: LogContext = {},
 	level: LogLevel = LogLevel.INFO
 ) {
-	console.log( {
-		context,
-		level,
-		message,
-		requestContext,
-		timestamp: Math.round( Date.now() / 1000 ),
-	} );
+	console.log(JSON.stringify({context, level, message, requestContext, timestamp: Math.round( Date.now() / 1000 ) }));
 }
 
 export function logError(

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -15,7 +15,7 @@ export function log(
 	requestContext: LogContext = {},
 	level: LogLevel = LogLevel.INFO
 ) {
-	console.log(JSON.stringify({context, level, message, requestContext, timestamp: Math.round( Date.now() / 1000 ) }));
+	console.log( JSON.stringify( { context, level, message, requestContext, timestamp: Math.round( Date.now() / 1000 ) } ) );
 }
 
 export function logError(

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -15,7 +15,13 @@ export function log(
 	requestContext: LogContext = {},
 	level: LogLevel = LogLevel.INFO
 ) {
-	console.log( JSON.stringify( { context, level, message, requestContext, timestamp: Math.round( Date.now() / 1000 ) } ) );
+	console.log( JSON.stringify ( {
+		context,
+		level,
+		message,
+		requestContext,
+		timestamp: Math.round( Date.now() / 1000 ),
+	} ) );
 }
 
 export function logError(

--- a/pages/_middleware.ts
+++ b/pages/_middleware.ts
@@ -15,16 +15,18 @@ export const middleware: NextMiddleware = ( req: NextRequest ) => {
 
 	// Ensures that when this response is returned, the Next.js chain will continue
 	const response = NextResponse.next();
+	const reqHeaderName = 'x-request-id';
 
-	if (req.headers.has( 'x-request-id' ) ) {
-		const sourceId = req.headers.get( 'x-request-id' );
+
+	if ( req.headers.has( reqHeaderName ) ) {
+		const sourceId = req.headers.get( reqHeaderName );
 
 		// Calling it sourceID allows to be differenciated from the requestID
 		// and potentially be sent to the WP backend alongside each WP query
 		response.headers.set( 'x-source-id', sourceId );
 		response.headers.set( 'x-request-path', pathName );
 
-		log( 'Middleware has been executed', {}, { sourceId, pathName } );
+		log( 'Middleware has been executed', { }, { sourceId, pathName } );
 	}
 
 	return response;

--- a/pages/_middleware.ts
+++ b/pages/_middleware.ts
@@ -1,33 +1,15 @@
 import { NextMiddleware, NextRequest, NextResponse } from 'next/server';
-import { log } from '@/lib/log';
 
 // Next.js middleware
 // ==================
 // https://nextjs.org/docs/middleware
 
 export const middleware: NextMiddleware = ( req: NextRequest ) => {
-	const pathName = req.nextUrl.pathname;
-
 	// Required health check endpoint on VIP. Do not remove.
-	if ( pathName === '/cache-healthcheck' ) {
+	if ( req.nextUrl.pathname === '/cache-healthcheck' ) {
 		return new NextResponse( 'Ok' );
 	}
 
-	// Ensures that when this response is returned, the Next.js chain will continue
-	const response = NextResponse.next();
-	const reqHeaderName = 'x-request-id';
-
-
-	if ( req.headers.has( reqHeaderName ) ) {
-		const sourceId = req.headers.get( reqHeaderName );
-
-		// Calling it sourceID allows to be differenciated from the requestID
-		// and potentially be sent to the WP backend alongside each WP query
-		response.headers.set( 'x-source-id', sourceId );
-		response.headers.set( 'x-request-path', pathName );
-
-		log( 'Middleware has been executed', { }, { sourceId, pathName } );
-	}
-
-	return response;
+	// Returning nothing means the request will continue as normal through the
+	// Next.js lifecycle.
 }

--- a/pages/_middleware.ts
+++ b/pages/_middleware.ts
@@ -13,6 +13,7 @@ export const middleware: NextMiddleware = ( req: NextRequest ) => {
 		return new NextResponse( 'Ok' );
 	}
 
+	// Ensures that when this response is returned, the Next.js chain will continue
 	const response = NextResponse.next();
 
 	if (req.headers.has( 'x-request-id' ) ) {

--- a/pages/_middleware.ts
+++ b/pages/_middleware.ts
@@ -7,6 +7,7 @@ import { log } from '@/lib/log';
 
 export const middleware: NextMiddleware = ( req: NextRequest ) => {
 	const pathName = req.nextUrl.pathname;
+
 	// Required health check endpoint on VIP. Do not remove.
 	if ( pathName === '/cache-healthcheck' ) {
 		return new NextResponse( 'Ok' );
@@ -14,17 +15,14 @@ export const middleware: NextMiddleware = ( req: NextRequest ) => {
 
 	const response = NextResponse.next();
 
-	// For local development, this is where you can optionally insert your own requestID
-	// A random UUID would work as well
-	if (req.headers.has('x-request-id')) {
-		const sourceId = req.headers.get('x-request-id');
+	if (req.headers.has( 'x-request-id' ) ) {
+		const sourceId = req.headers.get( 'x-request-id' );
 
-		response.headers.set('x-source-id', sourceId);
-		response.headers.set('x-request-path', pathName);
+		response.headers.set( 'x-source-id', sourceId );
+		response.headers.set( 'x-request-path', pathName );
 
-		log( 'Middleware has been executed', {}, {sourceId, pathName} );
+		log( 'Middleware has been executed', {}, { sourceId, pathName } );
 	}
 
-	// Returning nothing means the request will continue as normal through the
-	// Next.js lifecycle.
+	return response;
 }

--- a/pages/_middleware.ts
+++ b/pages/_middleware.ts
@@ -19,6 +19,8 @@ export const middleware: NextMiddleware = ( req: NextRequest ) => {
 	if (req.headers.has( 'x-request-id' ) ) {
 		const sourceId = req.headers.get( 'x-request-id' );
 
+		// Calling it sourceID allows to be differenciated from the requestID
+		// and potentially be sent to the WP backend alongside each WP query
 		response.headers.set( 'x-source-id', sourceId );
 		response.headers.set( 'x-request-path', pathName );
 

--- a/pages/_middleware.ts
+++ b/pages/_middleware.ts
@@ -1,13 +1,28 @@
 import { NextMiddleware, NextRequest, NextResponse } from 'next/server';
+import { log } from '@/lib/log';
 
 // Next.js middleware
 // ==================
 // https://nextjs.org/docs/middleware
 
 export const middleware: NextMiddleware = ( req: NextRequest ) => {
+	const pathName = req.nextUrl.pathname;
 	// Required health check endpoint on VIP. Do not remove.
-	if ( req.nextUrl.pathname === '/cache-healthcheck' ) {
+	if ( pathName === '/cache-healthcheck' ) {
 		return new NextResponse( 'Ok' );
+	}
+
+	const response = NextResponse.next();
+
+	// For local development, this is where you can optionally insert your own requestID
+	// A random UUID would work as well
+	if (req.headers.has('x-request-id')) {
+		const sourceId = req.headers.get('x-request-id');
+
+		response.headers.set('x-source-id', sourceId);
+		response.headers.set('x-request-path', pathName);
+
+		log( 'Middleware has been executed', {}, {sourceId, pathName} );
 	}
 
 	// Returning nothing means the request will continue as normal through the


### PR DESCRIPTION
This is meant to expand the logging that's done when a request comes into the Node.js app, and subsequent requests are made to the WP backend. This includes the following:

- Bake in the requestID added to each api/page request, as a field called sourceID. It's been named differently to allow the possibility of sending this alongside each WP query and group together different WP queries under a single parent. The WP query itself would have a requestID that would be different than the original page/api request's requestID.
- Bake in the path name that's been requested, so that it could be logged alongside each WP query.
- Add the cache, and payload size metrics to the logging that occurs for each WP query
- JSON stringify the logging around each WP query so it can be better ingested by a customer's tool of choice

An example of what these new additions would look like in the logs:

![image](https://user-images.githubusercontent.com/1771524/173915691-301f9137-54f2-4e76-a185-2cff89b97ade.png)

**Testing**

- `npm run dev`
- `curl --header "x-request-id: 34" -I "http://localhost:3000/latest/post"`
- view the logs that are generated, and ensure when you visit the same page it loads correctly