### PR TITLE
Update CircleCI tests to remove build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,5 @@
+---
+
 version: 2.1
 
 orbs:
@@ -11,18 +13,11 @@ workflows:
           npm-run: lint
   matrix-tests:
     jobs:
-      - node/run:
-          name: "build"
-          npm-run: build
-          matrix:
-            parameters:
-              version:
-                - "16.14"
-                - "14.19"
       - node/test:
           name: "unit tests"
           matrix:
             parameters:
               version:
-                - "16.14"
-                - "14.19"
+                - "18.9"
+                - "16.17"
+                - "14.20"


### PR DESCRIPTION
Update CircleCI tests to remove build step. This step broke when we updated the provided `.env` file to point to a local WordPress instance, which doesn't exist in the test environment.

Rationale: We could update this test to point to a live WordPress server, or create one inside the test environment. But this is a template repository, intended to be used by customers. Testing the build step in CI could be problematic, especially if it involves rendering (large amounts of) static content. The build step is validated as part of the deploy pipeline, so using it to "test" is not ideal or beneficial.

Additionally, this adds Node.js v18 as a test target.