### PR TITLE
Fix graphql endpoint rewrite

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -4,5 +4,8 @@
 	},
 	"plugins": [
 		"Automattic/vip-decoupled-bundle"
-	]
+	],
+	"mappings": {
+		".htaccess": ".wp-env/.htaccess"
+	}
 }

--- a/.wp-env/.htaccess
+++ b/.wp-env/.htaccess
@@ -1,0 +1,11 @@
+# Allow rewrites for GraphQL endpoint
+
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+</IfModule>


### PR DESCRIPTION
This enables URL rewrites in `wp-env` via a mapped `.htaccess` file, which makes the `/graphql` endpoint reachable by default.

## The problem

I ran into an issue getting the `wp-env` setup to work correctly today. After following the [local configuration setup](https://github.com/Automattic/vip-go-nextjs-skeleton#getting-started), the NextJS endpoint at http://localhost:3000 was showing an error:

![nextjs-error](https://user-images.githubusercontent.com/17870752/196089072-cb2b21e2-39b0-46d5-bedc-72effb260869.png)

This was caused by the http://localhost:8888/graphql endpoint returning an HTTP error:

![graphql-endpoint](https://user-images.githubusercontent.com/17870752/196089127-ff994f1c-e7a3-4304-b87d-1e7d7a762cc2.png)

Through a bit of debugging, I found that [`wp-graphql`'s rewrite rule](https://github.com/Automattic/vip-decoupled-bundle/blob/c5aa7ca84fce78eb09aced59e7e91e2925cd5527/lib/wp-graphql-1.6.12/src/Router.php#L91-L99) was being added successfully, but the [endpoint code was not getting called](https://github.com/Automattic/vip-decoupled-bundle/blob/c5aa7ca84fce78eb09aced59e7e91e2925cd5527/lib/wp-graphql-1.6.12/src/Router.php#L162-L165). On the bottom of the [Permalinks admin page](http://localhost:8888/wp-admin/options-permalink.php), I found this error indicating the problem:

![permalinks-error](https://user-images.githubusercontent.com/17870752/196089600-4575ddd7-8bde-423a-b2c3-c4770afae00e.png)

## The fix

Following a pattern found in [other WordPress repositories](https://github.com/WordPress/theme-directory-env/blob/trunk/.wp-env/.htaccess), I added a mapped `.htaccess` file to enable rewrites. I have verified this fixes the issue.

## Open questions

1. I'm not sure why I didn't run into this issue in https://github.com/Automattic/vip-go-nextjs-skeleton/pull/96. There don't appear to be any changes in this repository, [`vip-decoupled-bundle`](https://github.com/Automattic/vip-decoupled-bundle), or [`wp-env`](https://github.com/WordPress/gutenberg/blob/95c65750ac12440bb53446d0557d7c4e91968372/packages/env/CHANGELOG.md) that have modified the way rewrites or file permissions work. Why did this stop working?
2. I think we should add a admin header warning to [`vip-decoupled-bundle`](https://github.com/Automattic/vip-decoupled-bundle) when rewrites are not enabled (see [`got_url_rewrite()`](https://developer.wordpress.org/reference/functions/got_url_rewrite/)) since that may be a common issue for new WordPress projects. Are there any objections to including that error case?

Thank you!