### PR TITLE
Redirect `wp-admin` requests from the decoupled front end

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -88,6 +88,12 @@ module.exports = {
 	// https://nextjs.org/docs/api-reference/next.config.js/redirects
 	async redirects() {
 		return [
+			// Redirect /wp-admin requests to the WordPress admin.
+			{
+				source: '/wp-admin/:path*',
+				destination: `${ wordPressEndpoint }/wp-admin/:path*`,
+				permanent: false, // False, since the WP endpoint could change.
+			},
 			{
 				source: allPathsIncludingRoot,
 				destination: `${ wordPressEndpoint }/:path*`,


### PR DESCRIPTION
As a decoupled front-end, it is likely that the WordPress back-end is in a different domain. So users/editors trying to navigate to the WP back-end currently can’t.

I feel this should be baked-in in the skeleton.